### PR TITLE
Add Sync + Send traits to StunErrorInfo::Error

### DIFF
--- a/stun-rs/src/error.rs
+++ b/stun-rs/src/error.rs
@@ -36,7 +36,7 @@ pub enum StunErrorInfo {
     /// A [`String`] describing the error,
     Text(String),
     /// Source of error
-    Error(Box<dyn error::Error>),
+    Error(Box<dyn error::Error + Sync + Send>),
 }
 
 impl fmt::Display for StunErrorInfo {
@@ -128,7 +128,10 @@ impl StunError {
         }
     }
 
-    pub(crate) fn from_error(error_type: StunErrorType, e: Box<dyn error::Error>) -> Self {
+    pub(crate) fn from_error(
+        error_type: StunErrorType,
+        e: Box<dyn error::Error + Sync + Send>,
+    ) -> Self {
         Self {
             error_type,
             info: StunErrorInfo::Error(e),


### PR DESCRIPTION
Example code from https://github.com/sancane/rustun/blob/main/stun-rs/README.md#usage uses question mark operator `?` to propagate errors. I have tried to wrap a function around this example `pub fn stun_encode() -> anyhow::Result<()> {}`, and failed because of the following error:

```
`(dyn std::error::Error + 'static)` cannot be sent between threads safely
the trait `std::marker::Send` is not implemented for `(dyn std::error::Error + 'static)`
the trait `std::ops::FromResidual<std::result::Result<std::convert::Infallible, E>>` is implemented for `std::result::Result<T, F>`
required for `std::ptr::Unique<(dyn std::error::Error + 'static)>` to implement `std::marker::Send`
required for `anyhow::Error` to implement `std::convert::From<stun_rs::StunError>`
required for `std::result::Result<std::vec::Vec<u8>, anyhow::Error>` to implement `std::ops::FromResidual<std::result::Result<std::convert::Infallible, stun_rs::StunError>>`
```

This PR adds these traits and allows to glue `anyhow` results with the crate's error types.